### PR TITLE
Removing BrokerApi from namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ template/phpcs.xml
 template/.phpunit.result.cache
 .env
 template/.env
+.idea/

--- a/template/README.md
+++ b/template/README.md
@@ -49,7 +49,7 @@ Refer to the examples folder for further details on PHP usage
 $brokerAPI = new BrokerAPI();
 $factory = $brokerAPI->init();
 
-/** @var \{{ params.packageName }}\BrokerAPI\Applications\Producer $producer */
+/** @var \{{ params.packageName }}\Applications\Producer $producer */
 $producer = $factory->createApplication(
     PRODUCER_KEY,
     [

--- a/template/composer.json
+++ b/template/composer.json
@@ -29,7 +29,7 @@
     },
     "autoload": {
         "psr-4": {
-            "{{ params.packageName }}\\BrokerAPI\\": "src"
+            "{{ params.packageName }}\\": "src"
         },
         "files": [
             "configs/consts.php"
@@ -37,7 +37,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "{{ params.packageName }}\\BrokerAPI\\Tests\\": "tests"
+            "{{ params.packageName }}\\Tests\\": "tests"
         }
     },
     "scripts": {

--- a/template/examples/basic/consumer/Handlers/ExampleHandler.php
+++ b/template/examples/basic/consumer/Handlers/ExampleHandler.php
@@ -2,8 +2,8 @@
 
 namespace Examples\Basic\Consumer\Handlers;
 
-use {{ params.packageName }}\BrokerAPI\Handlers\HandlerContract;
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
+use {{ params.packageName }}\Handlers\HandlerContract;
+use {{ params.packageName }}\Messages\MessageContract;
 use PhpAmqpLib\Message\AMQPMessage;
 
 class ExampleHandler implements HandlerContract

--- a/template/examples/basic/consumer/index.php
+++ b/template/examples/basic/consumer/index.php
@@ -2,12 +2,12 @@
 require "../../../vendor/autoload.php";
 require "Handlers/ExampleHandler.php";
 
-use {{ params.packageName }}\BrokerAPI\BrokerAPI;
+use {{ params.packageName }};
 
 $brokerAPI = new BrokerAPI();
 $factory = $brokerAPI->init();
 
-/** @var \{{ params.packageName }}\BrokerAPI\Applications\Consumer $consumer */
+/** @var \{{ params.packageName }}\Applications\Consumer $consumer */
 $consumer = $factory->createApplication(
     CONSUMER_KEY,
     [

--- a/template/examples/basic/producer/index.php
+++ b/template/examples/basic/producer/index.php
@@ -1,13 +1,13 @@
 <?php
 require "../../../vendor/autoload.php";
 
-use {{ params.packageName }}\BrokerAPI\BrokerAPI;
-use {{ params.packageName }}\BrokerAPI\Messages\Example;
+use {{ params.packageName }};
+use {{ params.packageName }}\Messages\Example;
 
 $brokerAPI = new BrokerAPI();
 $factory = $brokerAPI->init();
 
-/** @var \{{ params.packageName }}\BrokerAPI\Applications\Producer $producer */
+/** @var \{{ params.packageName }}\Applications\Producer $producer */
 $producer = $factory->createApplication(
     PRODUCER_KEY,
     [

--- a/template/examples/rpc/consumer/Handlers/RPCExampleHandler.php
+++ b/template/examples/rpc/consumer/Handlers/RPCExampleHandler.php
@@ -3,9 +3,9 @@
 namespace Examples\RPC\Consumer\Handlers;
 
 use PhpAmqpLib\Message\AMQPMessage;
-use {{ params.packageName }}\BrokerAPI\Common\AMQPFactory;
-use {{ params.packageName }}\BrokerAPI\Handlers\AMQPRPCServerHandler;
-use {{ params.packageName }}\BrokerAPI\Messages\Example;
+use {{ params.packageName }}\Common\AMQPFactory;
+use {{ params.packageName }}\Handlers\AMQPRPCServerHandler;
+use {{ params.packageName }}\Messages\Example;
 
 /**
  * Created by PhpStorm.

--- a/template/examples/rpc/consumer/index.php
+++ b/template/examples/rpc/consumer/index.php
@@ -2,12 +2,12 @@
 require "../../../vendor/autoload.php";
 require "Handlers/RPCExampleHandler.php";
 
-use {{ params.packageName }}\BrokerAPI\BrokerAPI;
+use {{ params.packageName }};
 
 $brokerAPI = new BrokerAPI();
 $factory = $brokerAPI->init();
 
-/** @var \{{ params.packageName }}\BrokerAPI\Applications\Consumer $consumer */
+/** @var \{{ params.packageName }}\Applications\Consumer $consumer */
 $consumer = $factory->createApplication(
     CONSUMER_KEY,
     [

--- a/template/examples/rpc/producer/index.php
+++ b/template/examples/rpc/producer/index.php
@@ -1,13 +1,13 @@
 <?php
 require "../../../vendor/autoload.php";
 
-use {{ params.packageName }}\BrokerAPI\BrokerAPI;
-use {{ params.packageName }}\BrokerAPI\Messages\Example;
+use {{ params.packageName }};
+use {{ params.packageName }}\Messages\Example;
 
 $brokerAPI = new BrokerAPI();
 $factory = $brokerAPI->init();
 
-/** @var \{{ params.packageName }}\BrokerAPI\Applications\Producer $producer */
+/** @var \{{ params.packageName }}\Applications\Producer $producer */
 $producer = $factory->createApplication(
     PRODUCER_KEY,
     [

--- a/template/src/Applications/ApplicationContract.php
+++ b/template/src/Applications/ApplicationContract.php
@@ -10,11 +10,11 @@
  * Time: 14:38
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Applications;
+namespace {{ params.packageName }}\Applications;
 
-use {{ params.packageName }}\BrokerAPI\Common\FactoryContract;
-use {{ params.packageName }}\BrokerAPI\Handlers\HandlerContract;
-use {{ params.packageName }}\BrokerAPI\Infrastructure\BrokerClientContract;
+use {{ params.packageName }}\Common\FactoryContract;
+use {{ params.packageName }}\Handlers\HandlerContract;
+use {{ params.packageName }}\Infrastructure\BrokerClientContract;
 
 abstract class ApplicationContract
 {

--- a/template/src/Applications/Consumer.php
+++ b/template/src/Applications/Consumer.php
@@ -9,10 +9,10 @@
  * Time: 12:24
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Applications;
+namespace {{ params.packageName }}\Applications;
 
-use {{ params.packageName }}\BrokerAPI\Handlers\HandlerContract;
-use {{ params.packageName }}\BrokerAPI\Handlers\AMQPRPCServerHandler;
+use {{ params.packageName }}\Handlers\HandlerContract;
+use {{ params.packageName }}\Handlers\AMQPRPCServerHandler;
 
 final class Consumer extends ApplicationContract
 {

--- a/template/src/Applications/Producer.php
+++ b/template/src/Applications/Producer.php
@@ -10,10 +10,10 @@
  * Time: 20:22
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Applications;
+namespace {{ params.packageName }}\Applications;
 
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
-use {{ params.packageName }}\BrokerAPI\Handlers\AMQPRPCClientHandler;
+use {{ params.packageName }}\Messages\MessageContract;
+use {{ params.packageName }}\Handlers\AMQPRPCClientHandler;
 
 final class Producer extends ApplicationContract
 {

--- a/template/src/BrokerAPI.php
+++ b/template/src/BrokerAPI.php
@@ -9,11 +9,11 @@
  * Time: 10:41
  */
 
-namespace {{ params.packageName }}\BrokerAPI;
+namespace {{ params.packageName }};
 
 use Dotenv\Dotenv;
-use {{ params.packageName }}\BrokerAPI\Common\AMQPFactory;
-use {{ params.packageName }}\BrokerAPI\Common\FactoryContract;
+use {{ params.packageName }}\Common\AMQPFactory;
+use {{ params.packageName }}\Common\FactoryContract;
 
 final class BrokerAPI
 {

--- a/template/src/Common/AMQPFactory.php
+++ b/template/src/Common/AMQPFactory.php
@@ -8,15 +8,15 @@
  * Time: 11:39
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Common;
+namespace {{ params.packageName }}\Common;
 
-use {{ params.packageName }}\BrokerAPI\Handlers\HandlerContract;
-use {{ params.packageName }}\BrokerAPI\Infrastructure\BrokerClientContract;
-use {{ params.packageName }}\BrokerAPI\Infrastructure\AMQPBrokerClient;
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
-use {{ params.packageName }}\BrokerAPI\Applications\ApplicationContract;
-use {{ params.packageName }}\BrokerAPI\Applications\Consumer;
-use {{ params.packageName }}\BrokerAPI\Applications\Producer;
+use {{ params.packageName }}\Handlers\HandlerContract;
+use {{ params.packageName }}\Infrastructure\BrokerClientContract;
+use {{ params.packageName }}\Infrastructure\AMQPBrokerClient;
+use {{ params.packageName }}\Messages\MessageContract;
+use {{ params.packageName }}\Applications\ApplicationContract;
+use {{ params.packageName }}\Applications\Consumer;
+use {{ params.packageName }}\Applications\Producer;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 

--- a/template/src/Common/FactoryContract.php
+++ b/template/src/Common/FactoryContract.php
@@ -7,12 +7,12 @@
  * Time: 11:35
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Common;
+namespace {{ params.packageName }}\Common;
 
-use {{ params.packageName }}\BrokerAPI\Handlers\HandlerContract;
-use {{ params.packageName }}\BrokerAPI\Infrastructure\BrokerClientContract;
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
-use {{ params.packageName }}\BrokerAPI\Applications\ApplicationContract;
+use {{ params.packageName }}\Handlers\HandlerContract;
+use {{ params.packageName }}\Infrastructure\BrokerClientContract;
+use {{ params.packageName }}\Messages\MessageContract;
+use {{ params.packageName }}\Applications\ApplicationContract;
 
 interface FactoryContract
 {

--- a/template/src/Handlers/AMQPRPCClientHandler.php
+++ b/template/src/Handlers/AMQPRPCClientHandler.php
@@ -8,9 +8,9 @@
  * Time: 11:03
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Handlers;
+namespace {{ params.packageName }}\Handlers;
 
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
+use {{ params.packageName }}\Messages\MessageContract;
 use PhpAmqpLib\Message\AMQPMessage;
 
 class AMQPRPCClientHandler implements HandlerContract

--- a/template/src/Handlers/AMQPRPCServerHandler.php
+++ b/template/src/Handlers/AMQPRPCServerHandler.php
@@ -8,9 +8,9 @@
  * Time: 11:03
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Handlers;
+namespace {{ params.packageName }}\Handlers;
 
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
+use {{ params.packageName }}\Messages\MessageContract;
 use PhpAmqpLib\Message\AMQPMessage;
 
 abstract class AMQPRPCServerHandler implements HandlerContract

--- a/template/src/Handlers/HandlerContract.php
+++ b/template/src/Handlers/HandlerContract.php
@@ -8,9 +8,9 @@
  * Time: 11:03
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Handlers;
+namespace {{ params.packageName }}\Handlers;
 
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
+use {{ params.packageName }}\Messages\MessageContract;
 
 interface HandlerContract
 {

--- a/template/src/Infrastructure/AMQPBrokerClient.php
+++ b/template/src/Infrastructure/AMQPBrokerClient.php
@@ -8,17 +8,17 @@
  * Time: 14:37
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Infrastructure;
+namespace {{ params.packageName }}\Infrastructure;
 
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use Ramsey\Uuid\Uuid;
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
-use {{ params.packageName }}\BrokerAPI\Handlers\AMQPRPCServerHandler;
-use {{ params.packageName }}\BrokerAPI\Handlers\AMQPRPCClientHandler;
-use {{ params.packageName }}\BrokerAPI\Handlers\HandlerContract;
-use {{ params.packageName }}\BrokerAPI\Common\FactoryContract;
+use {{ params.packageName }}\Messages\MessageContract;
+use {{ params.packageName }}\Handlers\AMQPRPCServerHandler;
+use {{ params.packageName }}\Handlers\AMQPRPCClientHandler;
+use {{ params.packageName }}\Handlers\HandlerContract;
+use {{ params.packageName }}\Common\FactoryContract;
 
 class AMQPBrokerClient implements BrokerClientContract
 {

--- a/template/src/Infrastructure/BrokerClientContract.php
+++ b/template/src/Infrastructure/BrokerClientContract.php
@@ -10,12 +10,12 @@
  * Time: 11:11
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Infrastructure;
+namespace {{ params.packageName }}\Infrastructure;
 
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
-use {{ params.packageName }}\BrokerAPI\Handlers\AMQPRPCServerHandler;
-use {{ params.packageName }}\BrokerAPI\Handlers\HandlerContract;
-use {{ params.packageName }}\BrokerAPI\Common\FactoryContract;
+use {{ params.packageName }}\Messages\MessageContract;
+use {{ params.packageName }}\Handlers\AMQPRPCServerHandler;
+use {{ params.packageName }}\Handlers\HandlerContract;
+use {{ params.packageName }}\Common\FactoryContract;
 
 
 interface BrokerClientContract

--- a/template/src/Messages/$$message$$.php
+++ b/template/src/Messages/$$message$$.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace {{ params.packageName }}\BrokerAPI\Messages;
+namespace {{ params.packageName }}\Messages;
 {%- if message.description() or message.examples() %}/**{%- for line in message.description() | splitByLines %}
 * {{- line | safe }}{%- endfor %}{%- if message.examples() %}
 * Examples: {{- message.examples() | examplesToString | safe }}{%- endif %}

--- a/template/src/Messages/MessageContract.php
+++ b/template/src/Messages/MessageContract.php
@@ -8,7 +8,7 @@
  * Time: 11:03
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Messages;
+namespace {{ params.packageName }}\Messages;
 
 abstract class MessageContract implements \JsonSerializable
 {

--- a/template/tests/Applications/BaseApplicationTest.php
+++ b/template/tests/Applications/BaseApplicationTest.php
@@ -6,14 +6,14 @@
  * Time: 19:18
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Tests\Applications;
+namespace {{ params.packageName }}\Tests\Applications;
 
-use {{ params.packageName }}\BrokerAPI\Applications\Consumer;
-use {{ params.packageName }}\BrokerAPI\Applications\Producer;
-use {{ params.packageName }}\BrokerAPI\Common\FactoryContract;
-use {{ params.packageName }}\BrokerAPI\Handlers\HandlerContract;
-use {{ params.packageName }}\BrokerAPI\Infrastructure\BrokerClientContract;
-use {{ params.packageName }}\BrokerAPI\Tests\BaseTest;
+use {{ params.packageName }}\Applications\Consumer;
+use {{ params.packageName }}\Applications\Producer;
+use {{ params.packageName }}\Common\FactoryContract;
+use {{ params.packageName }}\Handlers\HandlerContract;
+use {{ params.packageName }}\Infrastructure\BrokerClientContract;
+use {{ params.packageName }}\Tests\BaseTest;
 
 class BaseApplicationTest extends BaseTest
 {

--- a/template/tests/BaseTest.php
+++ b/template/tests/BaseTest.php
@@ -6,7 +6,7 @@
  * Time: 11:02
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Tests;
+namespace {{ params.packageName }}\Tests;
 
 use Prophecy\PhpUnit\ProphecyTrait;
 

--- a/template/tests/BrokerAPITest.php
+++ b/template/tests/BrokerAPITest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace {{ params.packageName }}\BrokerAPI\Tests;
+namespace {{ params.packageName }}\Tests;
 
-use {{ params.packageName }}\BrokerAPI\BrokerAPI;
-use {{ params.packageName }}\BrokerAPI\Common\AMQPFactory;
+use {{ params.packageName }}\BrokerAPI;
+use {{ params.packageName }}\Common\AMQPFactory;
 
 class BrokerAPITest extends BaseTest
 {

--- a/template/tests/Common/AMQPFactoryTest.php
+++ b/template/tests/Common/AMQPFactoryTest.php
@@ -6,17 +6,17 @@
  * Time: 11:32
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Tests\Common\AMQP;
+namespace {{ params.packageName }}\Tests\Common\AMQP;
 
-use {{ params.packageName }}\BrokerAPI\Common\AMQPFactory;
-use {{ params.packageName }}\BrokerAPI\Infrastructure\AMQPBrokerClient;
-use {{ params.packageName }}\BrokerAPI\Infrastructure\BrokerClientContract;
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
-use {{ params.packageName }}\BrokerAPI\Applications\Consumer;
-use {{ params.packageName }}\BrokerAPI\Applications\Producer;
-use {{ params.packageName }}\BrokerAPI\Tests\BaseTest;
-use {{ params.packageName }}\BrokerAPI\Handlers\HandlerContract;
-use {{ params.packageName }}\BrokerAPI\Handlers\AMQPRPCClientHandler;
+use {{ params.packageName }}\Common\AMQPFactory;
+use {{ params.packageName }}\Infrastructure\AMQPBrokerClient;
+use {{ params.packageName }}\Infrastructure\BrokerClientContract;
+use {{ params.packageName }}\Messages\MessageContract;
+use {{ params.packageName }}\Applications\Consumer;
+use {{ params.packageName }}\Applications\Producer;
+use {{ params.packageName }}\Tests\BaseTest;
+use {{ params.packageName }}\Handlers\HandlerContract;
+use {{ params.packageName }}\Handlers\AMQPRPCClientHandler;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use Prophecy\Argument;

--- a/template/tests/Infrastructure/AMQPBrokerClientTest.php
+++ b/template/tests/Infrastructure/AMQPBrokerClientTest.php
@@ -6,15 +6,15 @@
  * Time: 14:42
  */
 
-namespace {{ params.packageName }}\BrokerAPI\Tests\Infrastructure;
+namespace {{ params.packageName }}\Tests\Infrastructure;
 
-use {{ params.packageName }}\BrokerAPI\Infrastructure\AMQPBrokerClient;
-use {{ params.packageName }}\BrokerAPI\Tests\BaseTest;
-use {{ params.packageName }}\BrokerAPI\Messages\MessageContract;
-use {{ params.packageName }}\BrokerAPI\Handlers\AMQPRPCClientHandler;
-use {{ params.packageName }}\BrokerAPI\Handlers\AMQPRPCServerHandler;
-use {{ params.packageName }}\BrokerAPI\Handlers\HandlerContract;
-use {{ params.packageName }}\BrokerAPI\Common\AMQPFactory;
+use {{ params.packageName }}\Infrastructure\AMQPBrokerClient;
+use {{ params.packageName }}\Tests\BaseTest;
+use {{ params.packageName }}\Messages\MessageContract;
+use {{ params.packageName }}\Handlers\AMQPRPCClientHandler;
+use {{ params.packageName }}\Handlers\AMQPRPCServerHandler;
+use {{ params.packageName }}\Handlers\HandlerContract;
+use {{ params.packageName }}\Common\AMQPFactory;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;


### PR DESCRIPTION
Remove \BrokeApi from PHP namespaces

## Description

Removed \BrokeApi from PHP namespaces, now only defined namespace in generator parameters is used

## Motivation and context

When generating PHP files for external project the generated files were not PSR-4 compliant, since added BrokerApi string in namespace required additional sub-folder

## How has this been tested?

composer run test and with external project

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
